### PR TITLE
feat: implement dashboard frontend and summary API

### DIFF
--- a/packages/backend/src/index.js
+++ b/packages/backend/src/index.js
@@ -16,6 +16,7 @@ const templatesRouter = require('./routes/templates');
 const datasetsRouter = require('./routes/datasets');
 const schedulesRouter = require('./routes/schedules');
 const reportsRouter = require('./routes/reports');
+const dashboardRouter = require('./routes/dashboard');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -27,6 +28,7 @@ app.use('/api/templates', templatesRouter);
 app.use('/api/datasets', datasetsRouter);
 app.use('/api/schedules', schedulesRouter);
 app.use('/api/reports', reportsRouter);
+app.use('/api/dashboard', dashboardRouter);
 
 app.listen(PORT, () => {
   console.log(`Backend server running on http://localhost:${PORT}`);

--- a/packages/backend/src/routes/dashboard.js
+++ b/packages/backend/src/routes/dashboard.js
@@ -1,0 +1,89 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../db');
+
+router.get('/summary', (req, res) => {
+  // Get all templates with their schedule and last run info
+  const templates = db
+    .prepare(
+      `SELECT
+        t.id,
+        t.name,
+        t.description,
+        t.created_at,
+        t.updated_at,
+        s.id AS schedule_id,
+        s.frequency,
+        s.time AS schedule_time,
+        s.enabled AS schedule_enabled,
+        rh.status AS last_run_status,
+        rh.created_at AS last_run_at
+      FROM templates t
+      LEFT JOIN schedules s ON s.template_id = t.id
+      LEFT JOIN (
+        SELECT template_id, status, created_at,
+          ROW_NUMBER() OVER (PARTITION BY template_id ORDER BY created_at DESC) AS rn
+        FROM run_history
+      ) rh ON rh.template_id = t.id AND rh.rn = 1
+      ORDER BY t.updated_at DESC`
+    )
+    .all()
+    .map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      schedule: row.schedule_id
+        ? {
+            id: row.schedule_id,
+            frequency: row.frequency,
+            time: row.schedule_time,
+            enabled: !!row.schedule_enabled,
+          }
+        : null,
+      last_run: row.last_run_status
+        ? {
+            status: row.last_run_status,
+            created_at: row.last_run_at,
+          }
+        : null,
+    }));
+
+  // Compute stats
+  const templateCount = db
+    .prepare('SELECT COUNT(*) AS count FROM templates')
+    .get().count;
+
+  const activeSchedules = db
+    .prepare('SELECT COUNT(*) AS count FROM schedules WHERE enabled = 1')
+    .get().count;
+
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+  const weekStart = oneWeekAgo.toISOString();
+
+  const reportsThisWeek = db
+    .prepare(
+      'SELECT COUNT(*) AS count FROM run_history WHERE created_at >= ?'
+    )
+    .get(weekStart).count;
+
+  const failedThisWeek = db
+    .prepare(
+      "SELECT COUNT(*) AS count FROM run_history WHERE status = 'failed' AND created_at >= ?"
+    )
+    .get(weekStart).count;
+
+  res.json({
+    templates,
+    stats: {
+      template_count: templateCount,
+      active_schedules: activeSchedules,
+      reports_this_week: reportsThisWeek,
+      failed_this_week: failedThisWeek,
+    },
+  });
+});
+
+module.exports = router;

--- a/packages/frontend/src/components/Dashboard.css
+++ b/packages/frontend/src/components/Dashboard.css
@@ -1,0 +1,239 @@
+/* Stats Bar */
+.stats-bar {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.stat-card--danger .stat-value {
+  color: #e74c3c;
+}
+
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1a1a2e;
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+/* Report Cards Grid */
+.report-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.report-card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.report-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.report-card__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+.report-card__status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  text-transform: capitalize;
+}
+
+.report-card__status--success {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.report-card__status--failed {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.report-card__desc {
+  font-size: 0.85rem;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.report-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.report-card__schedule--none {
+  font-style: italic;
+}
+
+.report-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
+  border-top: 1px solid #f0f0f5;
+}
+
+/* Buttons */
+.btn {
+  padding: 0.4rem 0.85rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.btn:hover {
+  opacity: 0.85;
+}
+
+.btn--primary {
+  background: #1a1a2e;
+  color: #fff;
+}
+
+.btn--secondary {
+  background: #e5e7eb;
+  color: #1a1a2e;
+}
+
+.btn--danger {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+/* Dashboard Page */
+.dashboard-header {
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-header h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1a1a2e;
+}
+
+.dashboard-loading,
+.dashboard-error {
+  text-align: center;
+  padding: 3rem;
+  color: #6b7280;
+}
+
+.dashboard-error {
+  color: #991b1b;
+}
+
+/* Empty State */
+.empty-state {
+  text-align: center;
+  padding: 4rem 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.empty-state__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1a1a2e;
+  margin-bottom: 0.5rem;
+}
+
+.empty-state__text {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin-bottom: 1.5rem;
+}
+
+.empty-state__link {
+  display: inline-block;
+  padding: 0.5rem 1.25rem;
+  background: #1a1a2e;
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: opacity 0.15s;
+}
+
+.empty-state__link:hover {
+  opacity: 0.85;
+}
+
+/* Confirm Dialog */
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.confirm-dialog {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+}
+
+.confirm-dialog p {
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+  color: #1a1a2e;
+}
+
+.confirm-dialog__actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .stats-bar {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .report-cards-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/frontend/src/components/ReportCard.jsx
+++ b/packages/frontend/src/components/ReportCard.jsx
@@ -1,0 +1,67 @@
+import './Dashboard.css';
+
+function formatDate(dateStr) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function ReportCard({ template, onRunNow, onEdit, onDelete }) {
+  const { schedule, last_run } = template;
+
+  return (
+    <div className="report-card">
+      <div className="report-card__header">
+        <h3 className="report-card__title">{template.name}</h3>
+        {last_run && (
+          <span
+            className={`report-card__status report-card__status--${last_run.status}`}
+          >
+            {last_run.status}
+          </span>
+        )}
+      </div>
+
+      {template.description && (
+        <p className="report-card__desc">{template.description}</p>
+      )}
+
+      <div className="report-card__meta">
+        {schedule ? (
+          <span className="report-card__schedule">
+            {schedule.frequency} at {schedule.time}
+            {!schedule.enabled && ' (paused)'}
+          </span>
+        ) : (
+          <span className="report-card__schedule report-card__schedule--none">
+            No schedule
+          </span>
+        )}
+        {last_run && (
+          <span className="report-card__last-run">
+            Last run: {formatDate(last_run.created_at)}
+          </span>
+        )}
+      </div>
+
+      <div className="report-card__actions">
+        <button className="btn btn--primary" onClick={() => onRunNow(template)}>
+          Run Now
+        </button>
+        <button className="btn btn--secondary" onClick={() => onEdit(template)}>
+          Edit
+        </button>
+        <button className="btn btn--danger" onClick={() => onDelete(template)}>
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ReportCard;

--- a/packages/frontend/src/components/StatsBar.jsx
+++ b/packages/frontend/src/components/StatsBar.jsx
@@ -1,0 +1,26 @@
+import './Dashboard.css';
+
+const statItems = [
+  { key: 'template_count', label: 'Total Templates' },
+  { key: 'active_schedules', label: 'Active Schedules' },
+  { key: 'reports_this_week', label: 'Reports This Week' },
+  { key: 'failed_this_week', label: 'Failed This Week' },
+];
+
+function StatsBar({ stats }) {
+  return (
+    <div className="stats-bar">
+      {statItems.map((item) => (
+        <div
+          key={item.key}
+          className={`stat-card${item.key === 'failed_this_week' && stats[item.key] > 0 ? ' stat-card--danger' : ''}`}
+        >
+          <span className="stat-value">{stats[item.key]}</span>
+          <span className="stat-label">{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default StatsBar;

--- a/packages/frontend/src/pages/Dashboard.jsx
+++ b/packages/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,128 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import api from '../api';
+import StatsBar from '../components/StatsBar';
+import ReportCard from '../components/ReportCard';
+import '../components/Dashboard.css';
+
 function Dashboard() {
-  return <h1>Dashboard</h1>;
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [deleteTarget, setDeleteTarget] = useState(null);
+
+  const fetchDashboard = useCallback(async () => {
+    try {
+      setError(null);
+      const result = await api.get('/dashboard/summary');
+      setData(result);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  const handleRunNow = async (template) => {
+    try {
+      await api.post('/reports/generate', { template_id: template.id });
+      fetchDashboard();
+    } catch (err) {
+      setError(`Failed to run report: ${err.message}`);
+    }
+  };
+
+  const handleEdit = (template) => {
+    navigate(`/templates/${template.id}`);
+  };
+
+  const handleDelete = (template) => {
+    setDeleteTarget(template);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await api.delete(`/templates/${deleteTarget.id}`);
+      setDeleteTarget(null);
+      fetchDashboard();
+    } catch (err) {
+      setError(`Failed to delete template: ${err.message}`);
+    }
+  };
+
+  if (loading) {
+    return <div className="dashboard-loading">Loading dashboard...</div>;
+  }
+
+  if (error && !data) {
+    return <div className="dashboard-error">Error: {error}</div>;
+  }
+
+  const { templates, stats } = data;
+
+  return (
+    <div>
+      <div className="dashboard-header">
+        <h1>Dashboard</h1>
+      </div>
+
+      {error && <div className="dashboard-error">{error}</div>}
+
+      <StatsBar stats={stats} />
+
+      {templates.length === 0 ? (
+        <div className="empty-state">
+          <h2 className="empty-state__title">No templates yet</h2>
+          <p className="empty-state__text">
+            Create your first report template to get started.
+          </p>
+          <Link to="/templates" className="empty-state__link">
+            Create Template
+          </Link>
+        </div>
+      ) : (
+        <div className="report-cards-grid">
+          {templates.map((template) => (
+            <ReportCard
+              key={template.id}
+              template={template}
+              onRunNow={handleRunNow}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
+
+      {deleteTarget && (
+        <div className="confirm-overlay" onClick={() => setDeleteTarget(null)}>
+          <div className="confirm-dialog" onClick={(e) => e.stopPropagation()}>
+            <p>
+              Are you sure you want to delete <strong>{deleteTarget.name}</strong>?
+              This action cannot be undone.
+            </p>
+            <div className="confirm-dialog__actions">
+              <button
+                className="btn btn--secondary"
+                onClick={() => setDeleteTarget(null)}
+              >
+                Cancel
+              </button>
+              <button className="btn btn--danger" onClick={confirmDelete}>
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default Dashboard;


### PR DESCRIPTION
## Summary

- **Backend**: Added `GET /api/dashboard/summary` endpoint (`packages/backend/src/routes/dashboard.js`) that returns all templates with schedule info and last run status, plus aggregated stats (template count, active schedules, reports this week, failed this week)
- **Frontend**: Built `StatsBar.jsx` component displaying 4 stat cards, `ReportCard.jsx` showing template name/schedule/status with Run Now/Edit/Delete actions, and updated `Dashboard.jsx` to fetch data, compose components, handle actions (run, edit, delete with confirmation), and show empty state
- **Styles**: Added `Dashboard.css` with responsive grid layouts for stats bar and report cards, button styles, confirmation dialog overlay, and empty state

Closes #10

## Test plan

- [ ] Start backend (`npm run dev -w packages/backend`) and verify `GET /api/dashboard/summary` returns expected JSON shape
- [ ] Start frontend (`npm run dev -w packages/frontend`) and confirm dashboard renders stats bar and report cards (or empty state if no templates)
- [ ] Verify "Run Now" button posts to `/api/reports/generate` and refreshes dashboard
- [ ] Verify "Edit" button navigates to `/templates/:id`
- [ ] Verify "Delete" button shows confirmation dialog, and confirming deletes the template
- [ ] Verify responsive layout on smaller screens (stats bar 2-col, cards single-col)
- [ ] Run `npm run build` to verify production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)